### PR TITLE
add patch for solokeys

### DIFF
--- a/0010-Add-SoloKeys-devices.patch
+++ b/0010-Add-SoloKeys-devices.patch
@@ -1,0 +1,23 @@
+Date: Fri, 6 Nov 2020 10:27:25 +0100
+Subject: [PATCH] Add Solokeys
+
+---
+ hid_transport.py | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/u2flib_host/hid_transport.py b/u2flib_host/hid_transport.py
+index 88a33e0..2b82747 100644
+--- a/u2flib_host/hid_transport.py
++++ b/u2flib_host/hid_transport.py
+@@ -62,7 +62,7 @@ DEVICES = [
+     (0x20a0, 0x42b1),  # Nitrokey FIDO2
+     (0x20a0, 0x42b2),  # Nitrokey FIDO2 NFC (future model)
+     (0x20a0, 0x42b3),  # Safetech SafeKey
+-
++    (0x0483, 0xa2ca),  # SoloKeys U2F/FIDO2
+ ]
+ HID_RPT_SIZE = 64
+ 
+-- 
+2.21.3
+

--- a/debian-series.conf
+++ b/debian-series.conf
@@ -7,3 +7,4 @@
 0007-Add-Trezor-VID-PID-close-42.patch
 0008-Add-reference-to-python-fido2-in-README.patch
 0009-Add-Nitrokey-devices.patch
+0010-Add-SoloKeys-devices.patch


### PR DESCRIPTION
Allow the USBID of all devices using the firmware from solokeys,

see
https://github.com/solokeys/solo/blob/880d54a4f0e00e32c25b47cfe8482de21a3a49ba/targets/stm32l432/lib/usbd/usbd_desc.c#L53

This concerns all tokens by https://solokeys.com/.

I can confirm that registration and authentication works with the
SOMU version of their tokens.