### PR TITLE
include solokey patch in fedora builds

### DIFF
--- a/python3-u2flib-host.spec.in
+++ b/python3-u2flib-host.spec.in
@@ -21,6 +21,7 @@ Patch06: 0006-Added-OnlyKey-device.patch
 Patch07: 0007-Add-Trezor-VID-PID-close-42.patch
 Patch08: 0008-Add-reference-to-python-fido2-in-README.patch
 Patch09: 0009-Add-Nitrokey-devices.patch
+Patch10: 0010-Add-SoloKeys-devices.patch
 
 BuildRequires:  python%{python3_pkgversion}-devel
 BuildRequires:  python%{python3_pkgversion}-cryptography >= 1.0


### PR DESCRIPTION
After the latest update I realized that my original [patch](https://github.com/QubesOS/qubes-python-u2flib-host/pull/5) was not included in fedora builds. I suspect that this should do the trick now.