### PR TITLE
Switch from wget to curl

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-VERSION := $(shell cat version)
+VERSION := $(file <version)
 URL := https://files.pythonhosted.org/packages/source/p/python-u2flib-host/python-u2flib-host-$(VERSION).tar.gz
 
 SRC_FILE = $(notdir $(URL))
@@ -12,7 +12,7 @@ endif
 SHELL := /bin/bash
 %: %.sha256
 	@$(FETCH_CMD) $@$(UNTRUSTED_SUFF) $(URL)
-	@sha256sum --status -c <(printf "$$(cat $<)  -\n") <$@$(UNTRUSTED_SUFF) || \
+	@sha256sum --strict --status -c <(printf "$(file <$<)  -\n") <$@$(UNTRUSTED_SUFF) || \
 		{ echo "Wrong SHA256 checksum on $@$(UNTRUSTED_SUFF)!"; exit 1; }
 	@mv $@$(UNTRUSTED_SUFF) $@
 

--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,9 @@ SRC_FILE = $(notdir $(URL))
 
 UNTRUSTED_SUFF := .UNTRUSTED
 
-FETCH_CMD := wget --no-use-server-timestamps -q -O
+ifeq ($(FETCH_CMD),)
+$(error "You can not run this Makefile without having FETCH_CMD defined")
+endif
 
 SHELL := /bin/bash
 %: %.sha256


### PR DESCRIPTION
curl has a better security track record than wget, and on Fedora uses a
better TLS library (OpenSSL instead of GnuTLS).  This change also adds
REPO_PROXY support.